### PR TITLE
Make FreeBSD 11 compile for ERL

### DIFF
--- a/buildimg.sh
+++ b/buildimg.sh
@@ -28,6 +28,8 @@ mkdir ${WORKDIR}/tree
 
 # Download packages
 cp /etc/resolv.conf ${WORKDIR}/tree/etc/
+mkdir -p ${WORKDIR}/tree/usr/local/etc/pkg/repos/
+sed -e 's/quarterly/latest/' ${WORKDIR}/tree/etc/pkg/FreeBSD.conf > ${WORKDIR}/tree/usr/local/etc/pkg/repos/FreeBSD.conf
 pkg -c ${WORKDIR}/tree install -Fy pkg djbdns isc-dhcp43-server
 rm ${WORKDIR}/tree/etc/resolv.conf
 

--- a/buildimg.sh
+++ b/buildimg.sh
@@ -12,7 +12,7 @@ export TARGET=mips
 export TARGET_ARCH=mips64
 export KERNCONF=ERL
 export ALL_MODULES=YES
-export WITHOUT_MODULES="cxgbe mwlfw netfpga10g otusfw ralfw usb rtwnfw"
+export WITHOUT_MODULES="urtwnfw cxgbe mwlfw netfpga10g otusfw ralfw usb rtwnfw"
 
 # Create working space
 WORKDIR=`env TMPDIR=\`pwd\` mktemp -d -t ERLBUILD`


### PR DESCRIPTION
When trying to compile FreeBSD, I was greeted with an error message about `urtwnfw`, so I disabled it. 

Additionally, there are no binary packages available for FreeBSD 10 (anymore?), so building on FreeBSD 10 seems to be broken now.

There are binary MIPS64 packages available for FreeBSD 11, but no quarterly packages seem to be maintained at this time. In order to make this work, I added a `sed`-command to the script that writes a new pkg configuration file.

With these changes, I was able to write a working ERL image using FreeBSD 11.
