### PR TITLE
Use set -e instead of #!/bin/sh -e

### DIFF
--- a/buildimg.sh
+++ b/buildimg.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 
 if [ -z "$1" ] || [ -z "$2" ]; then
 	echo "buildimg.sh srcdir disk.img"


### PR DESCRIPTION
The script may be invoked via 'sh buildimg.sh' in which case the shebang
line -e has no effect.